### PR TITLE
Avoid problems caused due to inflections.

### DIFF
--- a/src/Model/Behavior/EnumBehavior.php
+++ b/src/Model/Behavior/EnumBehavior.php
@@ -161,7 +161,7 @@ class EnumBehavior extends Behavior
     public function buildRules(Event $event, RulesChecker $rules)
     {
         foreach ($this->config('lists') as $alias => $config) {
-            $ruleName = 'isValid' . Inflector::classify($alias);
+            $ruleName = 'isValid' . Inflector::camelize($alias);
             $rules->add([$this, $ruleName], $ruleName, [
                 'errorField' => $config['field'],
                 'message' => $config['errorMessage']

--- a/src/Model/Behavior/Strategy/AbstractStrategy.php
+++ b/src/Model/Behavior/Strategy/AbstractStrategy.php
@@ -58,7 +58,7 @@ abstract class AbstractStrategy implements StrategyInterface
         }
 
         if (empty($config['field'])) {
-            $config['field'] = Inflector::underscore(Inflector::singularize($this->_alias));
+            $config['field'] = Inflector::underscore($this->_alias);
         }
 
         if (empty($config['errorMessage'])) {

--- a/tests/TestCase/Model/Behavior/EnumBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/EnumBehaviorTest.php
@@ -12,12 +12,19 @@ class ArticlesTable extends Table
     const STATUS_DRAFT = 'Drafted';
     const STATUS_ARCHIVE = 'Archived';
 
+    const NATURE_OF_BUSINESS_RENTALS = 'Rentals';
+    const NATURE_OF_BUSINESS_TOURS = 'Tours';
+
     public function initialize(array $config)
     {
         $this->addBehavior('CakeDC/Enum.Enum', ['lists' => [
             'priority' => ['errorMessage' => 'Invalid priority'],
             'status' => ['strategy' => 'const'],
             'category' => ['strategy' => 'config'],
+            'nature_of_business' => [
+                'strategy' => 'const',
+                'prefix' => 'NATURE_OF_BUSINESS'
+            ],
         ]]);
     }
 }
@@ -78,6 +85,12 @@ class EnumBehaviorTest extends TestCase
                     'field' => 'category',
                     'errorMessage' => 'The provided value is invalid'
                 ],
+                'nature_of_business' => [
+                    'strategy' => 'const',
+                    'prefix' => 'NATURE_OF_BUSINESS',
+                    'field' => 'nature_of_business',
+                    'errorMessage' => 'The provided value is invalid'
+                ],
             ],
         ];
 
@@ -88,6 +101,7 @@ class EnumBehaviorTest extends TestCase
                         'priority' => ['errorMessage' => 'Invalid priority'],
                         'status' => ['strategy' => 'const', 'prefix' => 'STATUS'],
                         'category' => ['strategy' => 'config', 'prefix' => 'ARTICLE_CATEGORY'],
+                        'nature_of_business' => ['strategy' => 'const', 'prefix' => 'NATURE_OF_BUSINESS'],
                     ],
                 ],
                 $expected
@@ -98,6 +112,7 @@ class EnumBehaviorTest extends TestCase
                         'priority' => ['errorMessage' => 'Invalid priority'],
                         'status' => ['strategy' => 'const', 'prefix' => 'STATUS'],
                         'category' => ['strategy' => 'config', 'prefix' => 'ARTICLE_CATEGORY'],
+                        'nature_of_business' => ['strategy' => 'const', 'prefix' => 'NATURE_OF_BUSINESS'],
                     ],
                 ],
                 $expected
@@ -143,6 +158,13 @@ class EnumBehaviorTest extends TestCase
                     'Open Source Software',
                 ]
             ],
+            [
+                'nature_of_business',
+                [
+                    'NATURE_OF_BUSINESS_RENTALS' => 'Rentals',
+                    'NATURE_OF_BUSINESS_TOURS' => 'Tours',
+                ]
+            ],
         ];
     }
 
@@ -163,6 +185,7 @@ class EnumBehaviorTest extends TestCase
                     'priority' => 'PRIORITY_URGENT',
                     'status' => 'STATUS_DRAFT',
                     'category' => 2,
+                    'nature_of_business' => 'NATURE_OF_BUSINESS_TOURS',
                 ],
                 [
                     'category' => ['isValidCategory' => 'The provided value is invalid'],
@@ -173,10 +196,12 @@ class EnumBehaviorTest extends TestCase
                     'priority' => 'Urgent',
                     'status' => 'Drafted',
                     'category' => 1,
+                    'nature_of_business' => 'Invalid value',
                 ],
                 [
                     'priority' => ['isValidPriority' => 'Invalid priority'],
                     'status' => ['isValidStatus' => 'The provided value is invalid'],
+                    'nature_of_business' => ['isValidNatureOfBusiness' => 'The provided value is invalid'],
                 ]
             ]
         ];


### PR DESCRIPTION
I tried using the behavior setting list for `nature_of_business` as shown in test case and then tried to get enum list using `$table->enum('nature_of_business')` which resulted in `MissingEnumConfigurationException` exception. 

I had to dig through the code to figure out that the alias was getting converted to `nature_of_busines` which is non intuitive. So better to avoid this hidden "magic".
