### PR TITLE
Allow customize the class for const strategy

### DIFF
--- a/src/Model/Behavior/Strategy/ConstStrategy.php
+++ b/src/Model/Behavior/Strategy/ConstStrategy.php
@@ -75,8 +75,9 @@ class ConstStrategy extends AbstractStrategy
 
         $prefix = $this->config('prefix');
         $lowercase = $this->config('lowercase');
+        $className = $this->config('className') ?: get_class($this->_table);
         $length = strlen($prefix) + 1;
-        $classConstants = (new ReflectionClass(get_class($this->_table)))->getConstants();
+        $classConstants = (new ReflectionClass($className))->getConstants();
         $constants = [];
 
         foreach ($classConstants as $key => $value) {

--- a/tests/TestCase/Model/Behavior/Strategy/ConstStrategyTest.php
+++ b/tests/TestCase/Model/Behavior/Strategy/ConstStrategyTest.php
@@ -53,7 +53,7 @@ class ConstStrategyTest extends TestCase
         $this->StrategyEntity->initialize([
             'prefix' => 'STATUS',
             'lowercase' => true,
-            'className' => 'CakeDC\\Enum\\Test\\TestCase\\Model\\Behavior\\Strategy\\Article'
+            'className' => 'CakeDC\\Enum\\Test\\TestCase\\Model\\Behavior\\Strategy\\Article',
         ]);
     }
 

--- a/tests/TestCase/Model/Behavior/Strategy/ConstStrategyTest.php
+++ b/tests/TestCase/Model/Behavior/Strategy/ConstStrategyTest.php
@@ -13,6 +13,7 @@
 namespace CakeDC\Enum\Test\TestCase\Model\Behavior\Strategy;
 
 use CakeDC\Enum\Model\Behavior\Strategy\ConstStrategy;
+use Cake\ORM\Entity;
 use Cake\ORM\Table;
 use Cake\TestSuite\TestCase;
 
@@ -26,26 +27,46 @@ class ArticlesTable extends Table
     const STATUS_ARCHIVE = 'Archived';
 }
 
+class Article extends Entity
+{
+
+    const EXTRA_VALUE = 'Extra';
+
+    const STATUS_PUBLIC = 'Published';
+    const STATUS_DRAFT = 'Drafted';
+    const STATUS_ARCHIVE = 'Archived';
+}
+
 class ConstStrategyTest extends TestCase
 {
-    public $Strategy;
+    public $StrategyTable;
+
+    public $StrategyEntity;
 
     public function setUp()
     {
         parent::setUp();
-        $this->Strategy = new ConstStrategy('status', new ArticlesTable());
-        $this->Strategy->initialize(['prefix' => 'STATUS', 'lowercase' => true]);
+        $this->StrategyTable = new ConstStrategy('status', new ArticlesTable());
+        $this->StrategyTable->initialize(['prefix' => 'STATUS', 'lowercase' => true]);
+
+        $this->StrategyEntity = new ConstStrategy('status', new ArticlesTable());
+        $this->StrategyEntity->initialize([
+            'prefix' => 'STATUS',
+            'lowercase' => true,
+            'className' => 'CakeDC\\Enum\\Test\\TestCase\\Model\\Behavior\\Strategy\\Article'
+        ]);
     }
 
     public function tearDown()
     {
         parent::tearDown();
-        unset($this->Strategy);
+        unset($this->StrategyTable);
+        unset($this->StrategyEntity);
     }
 
-    public function testEnum()
+    public function testEnumTable()
     {
-        $result = $this->Strategy->enum();
+        $result = $this->StrategyTable->enum();
         $expected = [
             'public' => 'Published',
             'draft' => 'Drafted',
@@ -54,6 +75,20 @@ class ConstStrategyTest extends TestCase
         $this->assertEquals($expected, $result);
 
         // Cached list
-        $this->assertEquals($expected, $this->Strategy->enum());
+        $this->assertEquals($expected, $this->StrategyTable->enum());
+    }
+
+    public function testEnumEntity()
+    {
+        $result = $this->StrategyEntity->enum();
+        $expected = [
+            'public' => 'Published',
+            'draft' => 'Drafted',
+            'archive' => 'Archived',
+        ];
+        $this->assertEquals($expected, $result);
+
+        // Cached list
+        $this->assertEquals($expected, $this->StrategyEntity->enum());
     }
 }


### PR DESCRIPTION
In my development strategy I create constants on the Entity class, as the entity represents one object and it makes more sence to me to have constants like `Article::TYPE_DOCUMENT` then `ArticleTable::TYPE_DOCUMENT`.

However not to break the current functionality it would be nice, if I could configure the class used for contants:

``` PHP
$this->addBehavior('CakeDC/Enum.Enum', ['lists' => [
    'status' => [
        'strategy' => 'const',
        'prefix' => 'STATUS',
        'className' => 'App\\Model\\Entity\\Article'
    ],
]]);
```

I used the attribute name `className` which is the same as is used in Cake's associations definition.
