### PR TITLE
Change to accept a third-party strategy

### DIFF
--- a/src/Model/Behavior/EnumBehavior.php
+++ b/src/Model/Behavior/EnumBehavior.php
@@ -177,6 +177,7 @@ class EnumBehavior extends Behavior
         foreach ($lists as $alias => $config) {
             $return[$alias] = $this->strategy($alias, $config['strategy'])->enum($config);
         }
+
         return $return;
     }
 
@@ -198,6 +199,7 @@ class EnumBehavior extends Behavior
                 'message' => $config['errorMessage']
             ]);
         }
+
         return $rules;
     }
 

--- a/src/Model/Behavior/EnumBehavior.php
+++ b/src/Model/Behavior/EnumBehavior.php
@@ -54,6 +54,7 @@ class EnumBehavior extends Behavior
         'implementedMethods' => [
             'enum' => 'enum',
         ],
+        'classMap' => [],
         'lists' => [],
     ];
 
@@ -125,6 +126,9 @@ class EnumBehavior extends Behavior
      */
     protected function _normalizeConfig()
     {
+        $classMap = $this->config('classMap');
+        $this->_classMap = array_merge($this->_classMap, $classMap);
+
         $lists = $this->config('lists');
         $defaultStrategy = $this->config('defaultStrategy');
 

--- a/tests/TestCase/Model/Behavior/EnumBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/EnumBehaviorTest.php
@@ -12,6 +12,7 @@
 
 namespace CakeDC\Enum\Test\TestCase\Model\Behavior;
 
+use CakeDC\Enum\Model\Behavior\Strategy\AbstractStrategy;
 use Cake\Core\Configure;
 use Cake\ORM\Table;
 use Cake\ORM\TableRegistry;
@@ -40,6 +41,17 @@ class ArticlesTable extends Table
             'node_group' => ['strategy' => 'const', 'lowercase' => true],
             'norules' => ['strategy' => 'const', 'applicationRules' => false],
         ]]);
+    }
+}
+
+class ThirdPartyStrategy extends AbstractStrategy
+{
+    public function enum(array $config = [])
+    {
+        return [
+            1 => 'PHP',
+            2 => 'CSS'
+        ];
     }
 }
 
@@ -115,6 +127,7 @@ class EnumBehaviorTest extends TestCase
                     'lowercase' => true
                 ],
             ],
+            'classMap' => []
         ];
 
         return [
@@ -307,6 +320,36 @@ class EnumBehaviorTest extends TestCase
                 'ARCHIVE' => 'Archived',
             ],
         ];
+        $this->assertEquals($expected, $result);
+    }
+
+    public function provideThirdPartyStrategy()
+    {
+        return [
+            [
+                [
+                    'classMap' => ['third_party' => 'CakeDC\Enum\Test\TestCase\Model\Behavior\ThirdPartyStrategy'],
+                    'lists' => [
+                        'article_category' => ['strategy' => 'third_party']
+                    ]
+                ],
+                [
+                    1 => 'PHP',
+                    2 => 'CSS'
+                ]
+            ]
+        ];
+    }
+
+    /**
+     * @dataProvider provideThirdPartyStrategy
+     */
+    public function testThirdPartyStrategy(array $config, array $expected)
+    {
+        TableRegistry::clear();
+        $Articles = TableRegistry::get('CakeDC/Enum.Articles', ['table' => 'enum_articles']);
+        $Articles->addBehavior('CakeDC/Enum.Enum', $config);
+        $result = $Articles->enum('article_category');
         $this->assertEquals($expected, $result);
     }
 }


### PR DESCRIPTION
If open the strategy, my dream will be spread.

``` php
$this->addBehavior('CakeDC/Enum.Enum', [
    'classMap' => [
        'third_party' => 'OtherPlugin\Model\Behavior\Strategy\ThirdPartyStrategy'
    ],
    'lists' => [
        'article_category' => [
            'strategy' => 'third_party'
        ],
    ]
]);
```
