### PR TITLE
Updated Install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,10 @@ Enumeration list for [CakePHP 3](http://cakephp.org).
 Install
 -------
 
-Using [Composer][composer]:
+Using [Composer](http://getcomposer.org):
 
 ```
-composer require cakedc/enum:dev-master
+composer require cakedc/enum:~1.0
 ```
 
 You then need to load the plugin. You can use the shell command:


### PR DESCRIPTION
I've fixed the link to Composer and changed the composer line to install the latest stable release rather than `dev-master` in the readme file.
