### PR TITLE
Nested list

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,12 +4,13 @@ php:
   - 5.5
   - 5.6
   - 7.0
+  - 7.1
 
 sudo: false
 
 env:
   matrix:
-    - DB=mysql db_dsn='mysql://travis@0.0.0.0/cakephp_test'
+    - DB=mysql db_dsn='mysql://root@127.0.0.1/cakephp_test'
     - DB=pgsql db_dsn='postgres://postgres@127.0.0.1/cakephp_test'
     - DB=sqlite db_dsn='sqlite:///:memory:'
 
@@ -23,26 +24,22 @@ matrix:
     - php: 5.6
       env: PHPCS=1 DEFAULT=0
 
-    - php: 5.6
-      env: COVERALLS=1 DEFAULT=0 DB=mysql db_dsn='mysql://travis@0.0.0.0/cakephp_test'
-
 before_script:
-  - composer self-update
+  - if [[ $TRAVIS_PHP_VERSION != 7.0 ]]; then phpenv config-rm xdebug.ini; fi
+
   - composer install --prefer-dist --no-interaction
 
-  - sh -c "if [ '$DB' = 'mysql' ]; then mysql -e 'CREATE DATABASE cakephp_test;'; fi"
-  - sh -c "if [ '$DB' = 'pgsql' ]; then psql -c 'CREATE DATABASE cakephp_test;' -U postgres; fi"
-
-  - sh -c "if [ '$PHPCS' = '1' ]; then composer require cakephp/cakephp-codesniffer:dev-master; fi"
-
-  - sh -c "if [ '$COVERALLS' = '1' ]; then composer require --dev satooshi/php-coveralls:dev-master; fi"
-  - sh -c "if [ '$COVERALLS' = '1' ]; then mkdir -p build/logs; fi"
+  - if [ $DB = 'mysql' ]; then mysql -e 'CREATE DATABASE cakephp_test;'; fi
+  - if [ $DB = 'pgsql' ]; then psql -c 'CREATE DATABASE cakephp_test;' -U postgres; fi
 
 script:
-  - sh -c "if [ '$DEFAULT' = '1' ]; then phpunit --stderr; fi"
-  - sh -c "if [ '$PHPCS' = '1' ]; then ./vendor/bin/phpcs -p --extensions=php --standard=vendor/cakephp/cakephp-codesniffer/CakePHP ./src ./tests; fi"
-  - sh -c "if [ '$COVERALLS' = '1' ]; then phpunit --stderr --coverage-clover build/logs/clover.xml; fi"
-  - sh -c "if [ '$COVERALLS' = '1' ]; then php vendor/bin/coveralls -c .coveralls.yml -v; fi"
+  - if [[ $DEFAULT = 1 && $TRAVIS_PHP_VERSION != 7.0 ]]; then vendor/bin/phpunit; fi
+  - if [[ $DEFAULT = 1 && $TRAVIS_PHP_VERSION = 7.0 ]]; then vendor/bin/phpunit --coverage-clover=clover.xml; fi
+
+  - if [ '$PHPCS' = '1' ]; then ./vendor/bin/phpcs -p --extensions=php --standard=vendor/cakephp/cakephp-codesniffer/CakePHP ./src ./tests; fi
+
+after_success:
+  - if [[ $DEFAULT = 1 && $TRAVIS_PHP_VERSION = 7.0 ]]; then bash <(curl -s https://codecov.io/bash); fi
 
 notifications:
   email: false

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ CakeDC Enum Plugin
 ==================
 
 [![Build Status](https://img.shields.io/travis/CakeDC/Enum/master.svg?style=flat-square)](https://travis-ci.org/CakeDC/Enum)
-[![Coverage](https://img.shields.io/coveralls/CakeDC/Enum/master.svg?style=flat-square)](https://coveralls.io/r/CakeDC/Enum)
+[![Coverage](https://img.shields.io/codecov/c/github/CakeDC/Enum.svg?style=flat-square)](https://codecov.io/github/CakeDC/Enum)
 [![Total Downloads](https://img.shields.io/packagist/dt/cakedc/enum.svg?style=flat-square)](https://packagist.org/packages/cakedc/enum)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg?style=flat-square)](LICENSE)
 

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "require-dev": {
         "cakephp/cakephp": "~3.0",
         "cakephp/cakephp-codesniffer": "2.*",
-        "phpunit/phpunit": "4.1.*"
+        "phpunit/phpunit": "<6.0"
     },
     "autoload": {
         "psr-4": {

--- a/tests/TestCase/Model/Behavior/EnumBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/EnumBehaviorTest.php
@@ -262,6 +262,18 @@ class EnumBehaviorTest extends TestCase
         $this->assertEquals($expected, $result);
     }
 
+    public function testEnumNested()
+    {
+        $this->Articles->behaviors()->Enum->config('nested', true);
+        $result = $this->Articles->enum('priority');
+        $expected = [
+            ['value' => 'URGENT', 'text' => 'Urgent'],
+            ['value' => 'HIGH', 'text' => 'High'],
+            ['value' => 'NORMAL', 'text' => 'Normal'],
+        ];
+        $this->assertEquals($expected, $result);
+    }
+
     public function testAssociationsCreated()
     {
         $result = $this->Articles->associations()->keys();


### PR DESCRIPTION
This would be useful when the list is converted to JSON for consumption by JS code on client side. It ensures you get the exact order of values since if a flat key/value array is converted to JSON object you can't be sure of the order of the object properties.

I chose this form of nesting since it's also supported by FormHelper, so one can use same format for Cake's HTML views and json APIs.