### PR TITLE
Allow empty

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -22,14 +22,9 @@
         </listener>
     </listeners>
 
-    <!-- Prevent coverage reports from looking in tests and vendors -->
     <filter>
-        <blacklist>
-            <directory suffix=".php">./vendor/</directory>
-            <directory suffix=".ctp">./vendor/</directory>
-
-            <directory suffix=".php">./tests/</directory>
-            <directory suffix=".ctp">./tests/</directory>
-        </blacklist>
+        <whitelist>
+            <directory suffix=".ctp">./src/</directory>
+        </whitelist>
     </filter>
 </phpunit>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -24,7 +24,7 @@
 
     <filter>
         <whitelist>
-            <directory suffix=".ctp">./src/</directory>
+            <directory suffix=".php">./src/</directory>
         </whitelist>
     </filter>
 </phpunit>

--- a/src/Model/Behavior/EnumBehavior.php
+++ b/src/Model/Behavior/EnumBehavior.php
@@ -49,7 +49,10 @@ class EnumBehavior extends Behavior
      *           'prefix' => 'PRIORITY',
      *           'field' => 'priority',
      *           'errorMessage' => 'Invalid priority',
-     *           'applicationRules' => true
+     *           // Create application rule to ensure only valid enum value can be saved.
+     *           'applicationRules' => true,
+     *           // Allow saving field without any enum value.
+     *           'allowEmpty' => false
      *       ],
      *   ];
      *   ```
@@ -277,6 +280,10 @@ class EnumBehavior extends Behavior
 
         if (!$config = $this->config('lists.' . $alias)) {
             throw new MissingEnumConfigurationException([$alias]);
+        }
+
+        if (!$entity->has($config['field']) && Hash::get($config, 'allowEmpty') === true) {
+            return true;
         }
 
         return array_key_exists($entity->{$config['field']}, $this->enum($alias));

--- a/tests/TestCase/Model/Behavior/EnumBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/EnumBehaviorTest.php
@@ -31,6 +31,8 @@ class ArticlesTable extends Table
 
     const NORULES_FOO = 'Foo';
 
+    const OPTIONAL_BAR = 'Bar';
+
     public function initialize(array $config)
     {
         $this->addBehavior('CakeDC/Enum.Enum', ['lists' => [
@@ -40,6 +42,7 @@ class ArticlesTable extends Table
             'node_type' => ['strategy' => 'const'],
             'node_group' => ['strategy' => 'const', 'lowercase' => true],
             'norules' => ['strategy' => 'const', 'applicationRules' => false],
+            'optional' => ['strategy' => 'const', 'lowercase' => true, 'allowEmpty' => true],
         ]]);
     }
 }
@@ -128,6 +131,13 @@ class EnumBehaviorTest extends TestCase
                     'errorMessage' => 'The provided value is invalid',
                     'lowercase' => true
                 ],
+                'optional' => [
+                    'strategy' => 'const',
+                    'prefix' => 'OPTIONAL',
+                    'field' => 'optional',
+                    'errorMessage' => 'The provided value is invalid',
+                    'lowercase' => true
+                ],
             ],
             'classMap' => []
         ];
@@ -141,6 +151,7 @@ class EnumBehaviorTest extends TestCase
                         'category' => ['strategy' => 'config'],
                         'node_type' => ['strategy' => 'const'],
                         'node_group' => ['strategy' => 'const', 'lowercase' => true],
+                        'optional' => ['strategy' => 'const', 'lowercase' => true],
                     ],
                 ],
                 $expected
@@ -228,6 +239,7 @@ class EnumBehaviorTest extends TestCase
                     'node_type' => 'BLOG',
                     'node_group' => 'active',
                     'norules' => 'invalid',
+                    'optional' => 'bar',
                 ],
                 [
                     'category' => ['isValidCategory' => 'The provided value is invalid'],
@@ -240,7 +252,7 @@ class EnumBehaviorTest extends TestCase
                     'category' => 1,
                     'node_type' => 'Invalid value',
                     'node_group' => 'active',
-                    'norules' => 'invalid'
+                    'norules' => 'invalid',
                 ],
                 [
                     'priority' => ['isValidPriority' => 'Invalid priority'],
@@ -314,6 +326,9 @@ class EnumBehaviorTest extends TestCase
             ],
             'norules' => [
                 'FOO' => 'Foo',
+            ],
+            'optional' => [
+                'bar' => 'Bar',
             ],
         ];
         $this->assertEquals($expected, $result);


### PR DESCRIPTION
I have had use cases where a field should have either a valid enum value or can be null. Currently if `applicationRules` is `true` you can't save a field with null value. So I have added a new `allowEmpty` config (default `false`).