### PR TITLE
Check for interface instance not abstract class.

### DIFF
--- a/src/Model/Behavior/EnumBehavior.php
+++ b/src/Model/Behavior/EnumBehavior.php
@@ -15,7 +15,7 @@ namespace CakeDC\Enum\Model\Behavior;
 use BadMethodCallException;
 use CakeDC\Enum\Model\Behavior\Exception\MissingEnumConfigurationException;
 use CakeDC\Enum\Model\Behavior\Exception\MissingEnumStrategyException;
-use CakeDC\Enum\Model\Behavior\Strategy\AbstractStrategy;
+use CakeDC\Enum\Model\Behavior\Strategy\StrategyInterface;
 use Cake\Event\Event;
 use Cake\ORM\Behavior;
 use Cake\ORM\RulesChecker;
@@ -113,7 +113,7 @@ class EnumBehavior extends Behavior
 
         $this->_strategies[$alias] = $strategy;
 
-        if ($strategy instanceof AbstractStrategy) {
+        if ($strategy instanceof StrategyInterface) {
             return $strategy;
         }
 


### PR DESCRIPTION
Without this fix you can't use custom strategy which implements StrategyInterface but does not extend AbstractStrategy.