### PR TITLE
Set configuration key directly to prevent Enum config resets

### DIFF
--- a/Docs/Documentation/Configuration.md
+++ b/Docs/Documentation/Configuration.md
@@ -48,11 +48,9 @@ $this->addBehavior('CakeDC/Enum.Enum', ['lists' => [
 Using this strategy you'll need to add the values to key **"CakeDC/Enum"** in the global Configure class, for example:
 
 ```php
-Configure::write('CakeDC/Enum', [
-    'category' => [
-        'CakePHP',
-        'Open Source Software',
-    ]
+Configure::write('CakeDC/Enum.category', [
+    'CakePHP',
+    'Open Source Software',
 ]);
 ```
 Then you can configure the behaviour configuration like so:

--- a/Docs/Documentation/Examples.md
+++ b/Docs/Documentation/Examples.md
@@ -2,7 +2,7 @@
 
 ## Lookups Example
 
-Firstly you need to create a migration to populate the database for you create the migration you need to run this command: 
+Firstly you need to create a migration to populate the database for you create the migration you need to run this command:
 
 ``` bin/cake migration create MyCustomMigration ``` and in the change method you need to create the entries, for example:
 
@@ -31,12 +31,12 @@ public function change()
 }
 ```
 
-After that you need to set the configuration in the behavior load, for example: 
+After that you need to set the configuration in the behavior load, for example:
 
 ```php
 $this->addBehavior('CakeDC/Enum.Enum', ['lists' => [
     'priority' => [
-        'prefix' => 'PRIORITY'  
+        'prefix' => 'PRIORITY'
     ],
 ]]);
 ```
@@ -55,7 +55,7 @@ If you use the plural variable name, you don't need to do anything in special in
 
 ## Const Example
 
-Here you need to create some constants variables in your table class and configure your behavior to get them for example: 
+Here you need to create some constants variables in your table class and configure your behavior to get them for example:
 
 ```php
 class ArticlesTable extends Table
@@ -110,15 +110,13 @@ so, your constaints need to be in the Article entity class.
 
 ## Config Example
 
-Here you need to create some constants variables in you table class and configure your behavior to get them for example: 
+Here you need to create some constants variables in you table class and configure your behavior to get them for example:
 
 ```php
-Configure::write(ConfigStrategy::KEY, [ // or 'CakeDC/Enum' as key
-    'category' => [
-        'Published',
-        'Drafted',
-        'Archived'
-    ],
+Configure::write(ConfigStrategy::KEY . 'category', [ // or 'CakeDC/Enum.category' as key
+    'Published',
+    'Drafted',
+    'Archived'
 ]);
 ```
 

--- a/tests/TestCase/Model/Behavior/EnumBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/EnumBehaviorTest.php
@@ -71,12 +71,11 @@ class EnumBehaviorTest extends TestCase
     {
         parent::setUp();
 
-        Configure::write('CakeDC/Enum', [
-            'ARTICLE_CATEGORY' => [
+        Configure::write('CakeDC/Enum.ARTICLE_CATEGORY', [
                 'CakePHP',
                 'Open Source Software',
             ]
-        ]);
+        );
 
         $this->Articles = TableRegistry::get('CakeDC/Enum.Articles', [
             'className' => 'CakeDC\Enum\Test\TestCase\Model\Behavior\ArticlesTable',


### PR DESCRIPTION
As discussed on Slack with @steinkel 

/cc @liviascapin: This fixes our undefined notices issue.