### PR TITLE
Update PHP versions for Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,11 @@
 language: php
 
 php:
-  - 5.5
   - 5.6
   - 7.0
   - 7.1
+  - 7.2
+  - 7.3
 
 sudo: false
 


### PR DESCRIPTION
The minimum CakePHP requirement doesn't support PHP 5.5.