### PR TITLE
[2.x] Correct Plugin name

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -22,5 +22,5 @@ class Plugin extends BasePlugin
      *
      * @var string
      */
-    protected $name = 'BootstrapUI';
+    protected $name = 'Enum';
 }


### PR DESCRIPTION
We encountered an issue when loading the default flash element from friendsofcake\bootstrap-ui:

```
[Cake\View\Exception\MissingElementException] Element file `BootstrapUI.flash/default.php` could not be found.
 
The following paths were searched:
 
- `path\to\app\vendor\orca-services\cakephp-customer-app-theme\templates\plugin\BootstrapUI\Admin\element\flash/default.php`
- `path\to\app\vendor\orca-services\cakephp-customer-app-theme\templates\plugin\BootstrapUI\element\flash/default.php`
- `path\to\app\vendor\orca-services\cakephp-customer-app-theme\templates\Admin\element\flash/default.php`
- `path\to\app\vendor\orca-services\cakephp-customer-app-theme\templates\element\flash/default.php`
- `path\to\app\templates\plugin\BootstrapUI\Admin\element\flash/default.php`
- `path\to\app\templates\plugin\BootstrapUI\element\flash/default.php`
- `path\to\app\vendor\cakedc\enum\templates\Admin\element\flash/default.php`
- `path\to\app\vendor\cakedc\enum\templates\element\flash/default.php`
- `path\to\app\templates\Admin\element\flash/default.php`
- `path\to\app\templates\element\flash/default.php`
- `path\to\app\vendor\cakephp\cakephp\templates\Admin\element\flash/default.php`
- `path\to\app\vendor\cakephp\cakephp\templates\element\flash/default.php`
in path\to\app\vendor\cakephp\cakephp\src\View\View.php on line 710
Exception Attributes: array (
  'file' => 'flash/default.php',
  'paths' => 
  array (
    0 => 'path\\to\\app\\vendor\\orca-services\\cakephp-customer-app-theme\\templates\\plugin\\BootstrapUI\\Admin\\element\\',
    1 => 'path\\to\\app\\vendor\\orca-services\\cakephp-customer-app-theme\\templates\\plugin\\BootstrapUI\\element\\',
    2 => 'path\\to\\app\\vendor\\orca-services\\cakephp-customer-app-theme\\templates\\Admin\\element\\',
    3 => 'path\\to\\app\\vendor\\orca-services\\cakephp-customer-app-theme\\templates\\element\\',
    4 => 'path\\to\\app\\templates\\plugin\\BootstrapUI\\Admin\\element\\',
    5 => 'path\\to\\app\\templates\\plugin\\BootstrapUI\\element\\',
    6 => 'path\\to\\app\\vendor\\cakedc\\enum\\templates\\Admin\\element\\',
    7 => 'path\\to\\app\\vendor\\cakedc\\enum\\templates\\element\\',
    8 => 'path\\to\\app\\templates\\Admin\\element\\',
    9 => 'path\\to\\app\\templates\\element\\',
    10 => 'path\\to\\app\\vendor\\cakephp\\cakephp\\templates\\Admin\\element\\',
    11 => 'path\\to\\app\\vendor\\cakephp\\cakephp\\templates\\element\\',
  ),
)
```

The reason was, that the enum plugin set its plugin name to "BootstrapUI".