### PR TITLE
Set built rules through Event::setResult() instead of returning from method

### DIFF
--- a/src/Model/Behavior/EnumBehavior.php
+++ b/src/Model/Behavior/EnumBehavior.php
@@ -249,11 +249,13 @@ class EnumBehavior extends Behavior
     }
 
     /**
-     * @param \Cake\Event\EventInterface $event Event.
-     * @param \Cake\ORM\RulesChecker $rules Rules checker.
-     * @return \Cake\ORM\RulesChecker
+     * Build the rules for enumeration lists with activated application rules
+     *
+     * @param \Cake\Event\EventInterface $event The trigggered Event.
+     * @param \Cake\ORM\RulesChecker $rules The RulesChecker to ammend.
+     * @return void
      */
-    public function buildRules(EventInterface $event, RulesChecker $rules): RulesChecker
+    public function buildRules(EventInterface $event, RulesChecker $rules): void
     {
         foreach ($this->getConfig('lists') as $alias => $config) {
             if (Hash::get($config, 'applicationRules') === false) {
@@ -267,7 +269,7 @@ class EnumBehavior extends Behavior
             ]);
         }
 
-        return $rules;
+        $event->setResult($rules);
     }
 
     /**


### PR DESCRIPTION
Fixes:
```
Since 5.2.0: Returning a value from event listeners is deprecated. Use `$event->setResult()` instead in `Model.buildRules` of `CakeDC\Enum\Model\Behavior\EnumBehavior::buildRules()`
```